### PR TITLE
error `Chrome version must be >= 64.0.3282.0`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
 	&& sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends google-chrome-stable \
+	&& apt-get --only-upgrade install google-chrome-stable \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN wget https://noto-website.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip \


### PR DESCRIPTION
in my environment, the error shown below occured.
and I think [this gist](https://gist.github.com/mrtns/78d15e3263b2f6a231fe) will help us.
I added a line to update google-chrome-stable version.

```
ERROR: session not created exception: Chrome version must be >= 64.0.3282.0
  (Driver info: chromedriver=2.37.544315 (730aa6a5fdba159ac9f4c1e8cbc59bf1b5ce12b7),platform=Linux 4.13.0-32-generic x86_64) (WARNING: The server did not provide any stacktrace information)
Command duration or timeout: 273 milliseconds
Build info: version: '3.8.1', revision: '6e95a6684b', time: '2017-12-01T19:05:32.194Z'
System info: host: '44648281ab63', ip: '172.17.0.7', os.name: 'Linux', os.arch: 'amd64', os.version: '4.13.0-32-generic', java.version: '1.8.0_151'
Driver info: driver.version: unknown
```